### PR TITLE
Remove installation of rubocop and its extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,23 @@ This action runs [rubocop](https://github.com/rubocop/rubocop) with
 [reviewdog](https://github.com/reviewdog/reviewdog) on pull requests to improve
 code review experience.
 
+## Installation
+
+- Add `rubocop` to your Gemfile
+```ruby
+gem "rubocop"
+```
+
+- Add other rubocop extensions to your Gemfile (Optional)
+
+```ruby
+# Examples
+
+gem "rubocop-github", "~> 0.16.0"
+gem "rubocop-performance", require: false
+gem "rubocop-rails", require: false
+```
+
 ## Examples
 
 ### With `github-pr-check`
@@ -28,28 +45,7 @@ With `reporter: github-pr-review` a comment is added to the Pull Request Convers
 
 ### `github_token`
 
-**Required**. Must be in form of `github_token: ${{ secrets.github_token }}`'.
-
-### `rubocop_version`
-
-Optional. Set rubocop version. Possible values:
-* empty or omit: install latest version
-* `gemfile`: install version from Gemfile (`Gemfile.lock` should be presented, otherwise it will fallback to latest bundler version)
-* version (e.g. `0.90.0`): install said version
-
-### `rubocop_extensions`
-
-Optional. Set list of rubocop extensions with versions.
-
-By default install `rubocop-rails`, `rubocop-performance`, `rubocop-rspec`, `rubocop-i18n`, `rubocop-rake` with latest versions.
-Provide desired version delimited by `:` (e.g. `rubocop-rails:1.7.1`)
-
-Possible version values:
-* empty or omit (`rubocop-rails rubocop-rspec`): install latest version
-* `rubocop-rails:gemfile rubocop-rspec:gemfile`: install version from Gemfile (`Gemfile.lock` should be presented, otherwise it will fallback to latest bundler version)
-* version (e.g. `rubocop-rails:1.7.1 rubocop-rspec:2.0.0`): install said version
-
-You can combine `gemfile`, fixed and latest bundle version as you want to.
+**Required**. Must be in form of `github_token: ${{ secrets.GITHUB_TOKEN }}`'.
 
 ### `rubocop_flags`
 
@@ -106,20 +102,9 @@ jobs:
       - name: rubocop
         uses: reviewdog/action-rubocop@v1
         with:
-          rubocop_version: gemfile
-          rubocop_extensions: rubocop-rails:gemfile rubocop-rspec:gemfile
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review # Default is github-pr-check
 ```
-
-## Sponsor
-
-<p>
-  <a href="https://evrone.com/?utm_source=action-rubocop">
-    <img src="https://www.mgrachev.com/assets/static/evrone-sponsored-300.png"
-      alt="Sponsored by Evrone" width="210">
-  </a>
-</p>
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -5,11 +5,6 @@ inputs:
   github_token:
     description: 'GITHUB_TOKEN'
     required: true
-  rubocop_version:
-    description: 'Rubocop version'
-  rubocop_extensions:
-    description: 'Rubocop extensions'
-    default: 'rubocop-rails rubocop-performance rubocop-rspec rubocop-i18n rubocop-rake'
   rubocop_flags:
     description: 'Rubocop flags. (rubocop <rubocop_flags>)'
     default: ''

--- a/script.sh
+++ b/script.sh
@@ -15,76 +15,11 @@ echo '::group::🐶 Installing reviewdog ... https://github.com/reviewdog/review
 curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b "${TEMP_PATH}" "${REVIEWDOG_VERSION}" 2>&1
 echo '::endgroup::'
 
-echo '::group:: Installing rubocop with extensions ... https://github.com/rubocop/rubocop'
-# if 'gemfile' rubocop version selected
-if [ "${INPUT_RUBOCOP_VERSION}" = "gemfile" ]; then
-  # if Gemfile.lock is here
-  if [ -f 'Gemfile.lock' ]; then
-    # grep for rubocop version
-    RUBOCOP_GEMFILE_VERSION=$(ruby -ne 'print $& if /^\s{4}rubocop\s\(\K.*(?=\))/' Gemfile.lock)
-
-    # if rubocop version found, then pass it to the gem install
-    # left it empty otherwise, so no version will be passed
-    if [ -n "$RUBOCOP_GEMFILE_VERSION" ]; then
-      RUBOCOP_VERSION=$RUBOCOP_GEMFILE_VERSION
-      else
-        printf "Cannot get the rubocop's version from Gemfile.lock. The latest version will be installed."
-    fi
-    else
-      printf 'Gemfile.lock not found. The latest version will be installed.'
-  fi
-  else
-    # set desired rubocop version
-    RUBOCOP_VERSION=$INPUT_RUBOCOP_VERSION
-fi
-
-gem install -N rubocop --version "${RUBOCOP_VERSION}"
-
-# Traverse over list of rubocop extensions
-for extension in $INPUT_RUBOCOP_EXTENSIONS; do
-  # grep for name and version
-  INPUT_RUBOCOP_EXTENSION_NAME=$(echo "$extension" |awk 'BEGIN { FS = ":" } ; { print $1 }')
-  INPUT_RUBOCOP_EXTENSION_VERSION=$(echo "$extension" |awk 'BEGIN { FS = ":" } ; { print $2 }')
-
-  # if version is 'gemfile'
-  if [ "${INPUT_RUBOCOP_EXTENSION_VERSION}" = "gemfile" ]; then
-    # if Gemfile.lock is here
-    if [ -f 'Gemfile.lock' ]; then
-      # grep for rubocop extension version
-      RUBOCOP_EXTENSION_GEMFILE_VERSION=$(ruby -ne "print $& if /^\s{4}$INPUT_RUBOCOP_EXTENSION_NAME\s\(\K.*(?=\))/" Gemfile.lock)
-
-      # if rubocop extension version found, then pass it to the gem install
-      # left it empty otherwise, so no version will be passed
-      if [ -n "$RUBOCOP_EXTENSION_GEMFILE_VERSION" ]; then
-        RUBOCOP_EXTENSION_VERSION=$RUBOCOP_EXTENSION_GEMFILE_VERSION
-        else
-          printf "Cannot get the rubocop extension version from Gemfile.lock. The latest version will be installed."
-      fi
-      else
-        printf 'Gemfile.lock not found. The latest version will be installed.'
-    fi
-  else
-    # set desired rubocop extension version
-    RUBOCOP_EXTENSION_VERSION=$INPUT_RUBOCOP_EXTENSION_VERSION
-  fi
-
-  # Handle extensions with no version qualifier
-  if [ -z "${RUBOCOP_EXTENSION_VERSION}" ]; then
-    unset RUBOCOP_EXTENSION_VERSION_FLAG
-  else
-    RUBOCOP_EXTENSION_VERSION_FLAG="--version ${RUBOCOP_EXTENSION_VERSION}"
-  fi
-
-  # shellcheck disable=SC2086
-  gem install -N "${INPUT_RUBOCOP_EXTENSION_NAME}" ${RUBOCOP_EXTENSION_VERSION_FLAG}
-done
-echo '::endgroup::'
-
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 echo '::group:: Running rubocop with reviewdog 🐶 ...'
 # shellcheck disable=SC2086
-rubocop ${INPUT_RUBOCOP_FLAGS} \
+bundle exec rubocop ${INPUT_RUBOCOP_FLAGS} \
   | reviewdog -f=rubocop \
       -name="${INPUT_TOOL_NAME}" \
       -reporter="${INPUT_REPORTER}" \


### PR DESCRIPTION
- because there is no need to install rubocop in Rails Project.
- the better way is to add rubocop in Gemfile because which give you
  the ability to customize the rubocop extensions you wanted/needed